### PR TITLE
Fix Prev Filename, remove 'fakepath'

### DIFF
--- a/bootstrap.file-input.js
+++ b/bootstrap.file-input.js
@@ -79,8 +79,8 @@ $('input[type=file]').each(function(i,elem){
   $('.file-input-wrapper input[type=file]').change(function(){
 
     // Remove any previous file names
-    $(this).parent().next().has('file-input-name').remove();
-    $(this).parent().after('<span class="file-input-name">'+$(this).val()+'</span>');
+    $(this).parent().next('.file-input-name').remove();
+    $(this).parent().after('<span class="file-input-name">'+$(this).val().replace('C:\\fakepath\\','')+'</span>');
 
   });
 


### PR DESCRIPTION
Incorporated the fix to remove previous filenames, also automatically remove 'C:\fakepath\' from the filename
