### PR TITLE
Allow for multiple file inputs

### DIFF
--- a/bootstrap.file-input.js
+++ b/bootstrap.file-input.js
@@ -80,7 +80,12 @@ $('input[type=file]').each(function(i,elem){
 
     // Remove any previous file names
     $(this).parent().next('.file-input-name').remove();
-    $(this).parent().after('<span class="file-input-name">'+$(this).val().replace('C:\\fakepath\\','')+'</span>');
+    if ($(this).prop('files').length > 1) {
+      $(this).parent().after('<span class="file-input-name">'+$(this)[0].files.length+' files</span>');
+    }
+    else {
+      $(this).parent().after('<span class="file-input-name">'+$(this).val().replace('C:\\fakepath\\','')+'</span>');
+    }
 
   });
 


### PR DESCRIPTION
This update shows a count (e.g. "5 files") instead of just the first filename when you're using it on a file input that allows multiple files.
