### PR TITLE
handling file input change event via body

### DIFF
--- a/bootstrap.file-input.js
+++ b/bootstrap.file-input.js
@@ -86,7 +86,7 @@ $.fn.bootstrapFileInput = function() {
       });
     });
 
-    $('.file-input-wrapper input[type=file]').change(function(){
+    $('body').on('change', '.file-input-wrapper input[type=file]', function(){
 
       var fileName;
       fileName = $(this).val();


### PR DESCRIPTION
Hi! I discovered an issue - with original version file inputs that are cloned do not have change event handlers bound. This commit fixes that.
