### PR TITLE
Add new option : data-filename-placement

### DIFF
--- a/bootstrap.file-input.js
+++ b/bootstrap.file-input.js
@@ -38,7 +38,7 @@ $.fn.bootstrapFileInput = function() {
 
     // Now we're going to wrap that input field with a Bootstrap button.
     // The input will actually still be there, it will just be float above and transparent (done with the CSS).
-    $elem.wrap('<a class="file-input-wrapper btn btn-default ' + className + '"></a>').parent().prepend(buttonWord);
+    $elem.wrap('<a class="file-input-wrapper btn btn-default ' + className + '"></a>').parent().prepend($('<span></span>').html(buttonWord));
   })
 
   // After we have found all of the file inputs let's apply a listener for tracking the mouse movement.
@@ -100,7 +100,17 @@ $.fn.bootstrapFileInput = function() {
         fileName = fileName.substring(fileName.lastIndexOf('\\')+1,fileName.length);
       }
 
-      $(this).parent().after('<span class="file-input-name">'+fileName+'</span>');
+      var selectedFileNamePlacement = $(this).data('filename-placement') || 'outside';
+      if (selectedFileNamePlacement === 'inside') {
+        // Print the fileName inside
+        $(this).siblings('span').html(fileName);
+        $(this).attr('title', fileName);
+      } else if (selectedFileNamePlacement === 'outside') {
+        // Print the fileName aside (right after the the button)
+        $(this).parent().after('<span class="file-input-name">'+fileName+'</span>');
+      } else {
+        console.log('Error in bootstrap-file-input plugin : unknown placement [' + selectedFileNamePlacement + '] for selected filename');
+      }
     });
 
   });

--- a/demo.html
+++ b/demo.html
@@ -81,6 +81,12 @@ $('.file-inputs').bootstrapFileInput();
   <pre class="prettyprint">
 &lt;!-- Disable the styling --&gt;
 &lt;input type="file" data-bfi-disabled&gt;</pre>
+  
+  <input type="file" data-filename-placement="inside">
+
+  <pre class="prettyprint">
+&lt;!-- Display filename inside the button instead of its label --&gt;
+&lt;input type="file" data-filename-placement="inside"&gt;</pre>
 
   <h6>Compliance</h6>
 
@@ -108,6 +114,16 @@ $('.file-inputs').bootstrapFileInput();
         <td><code>data-bfi-disabled</code></td>
         <td><small>No value required</small></td>
         <td>When this attributes exists it prevents the file input from being styled</td>
+      </tr>
+      <tr>
+       <td><code>data-filename-placement</td>
+       <td><small>String ['<em>outside</em>', '<em>inside</em>']<br/>Default: '<em>outside</em>'</small></td>
+       <td>Defines where the selected file name will be displayed :
+         <ul>
+           <li><em>outside</em> to place it right after the button (DEFAULT)</li>
+           <li><em>intside</em> to place it inside the button, instead of the title</li>
+         </ul> 
+       </td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
Available values are `outside` (default) and `inside`.
When `data-filename-placement="inside"`, the selected file name will be displayed inside the button, instead of its label

``` html
<input type="file" 
    title="This text will be replaced by the selected file name"
    data-filename-placement="inside" />
```

In addition, I added a `<span>` to contain button text.
I also added an example in your `demo.html` file.
