### PR TITLE
define plugin before domReady

### DIFF
--- a/bootstrap.file-input.js
+++ b/bootstrap.file-input.js
@@ -10,7 +10,6 @@
   <a class="btn">Browse</a>
 
 */
-$(function() {
 
 $.fn.bootstrapFileInput = function() {
 
@@ -107,6 +106,7 @@ $.fn.bootstrapFileInput = function() {
 
 };
 
+$(function() {
 // Add the styles before the first stylesheet
 // This ensures they can be easily overridden with developer styles
 var cssHtml = '<style>'+


### PR DESCRIPTION
Currently the plugin definition is wrapped in `$(function(){})` - which means that it won't be registered until the dom is ready, rather than when the file is executed.

This tripped me up a bit while I was using this plugin
