### PR TITLE
Adding support for "data-bfi-processed-class" option

### DIFF
--- a/bootstrap.file-input.js
+++ b/bootstrap.file-input.js
@@ -18,6 +18,15 @@ $.fn.bootstrapFileInput = function() {
 
     var $elem = $(elem);
 
+    // Add [processed] class to avoid double processing of input file element
+    if (typeof $elem.attr('data-bfi-processed-class') != 'undefined') {
+      // Check if the element already has the [processed] flag on it and skip it if it does
+      if ($elem.hasClass($elem.attr('data-bfi-processed-class'))) {
+          return;
+      }
+      $elem.addClass($elem.attr('data-bfi-processed-class'));
+    }
+
     // Maybe some fields don't need to be standardized.
     if (typeof $elem.attr('data-bfi-disabled') != 'undefined') {
       return;


### PR DESCRIPTION
The new option, "data-bfi-processed-class", allows to define a class name that is added to every processed file input element. This allows to make sure that each input file element only gets processed once. 

This could be useful if multiple file input elements are injected into page's DOM dynamically using Javascript and bootstrap-file-input functionality needs to be applied to newly injected input file elements only.
