### PR TITLE
Update code to be compliant with jQuery 3.x

### DIFF
--- a/bootstrap.file-input.js
+++ b/bootstrap.file-input.js
@@ -56,7 +56,7 @@ $.fn.bootstrapFileInput = function() {
 
     // As the cursor moves over our new Bootstrap button we need to adjust the position of the invisible file input Browse button to be under the cursor.
     // This gives us the pointer cursor that FF denies us
-    $('.file-input-wrapper').mousemove(function(cursor) {
+    $('.file-input-wrapper').on('mousemove', function(cursor) {
 
       var input, wrapper,
         wrapperX, wrapperY,


### PR DESCRIPTION
Using [jQuery migrate plugin](https://github.com/jquery/jquery-migrate) (v3.0.1) to chek if my pages are compliant with jQuery 3.x, I saw that the code had deprecated feature. here is a fix